### PR TITLE
Convert contains to Like

### DIFF
--- a/Get-Specs.ps1
+++ b/Get-Specs.ps1
@@ -370,19 +370,19 @@ function getNotes {
     $5 = @()
     # bad software 
    foreach ($software in $badSoftware) { 
-        if ($installedBase.DisplayName -contains $software) { 
+        if ($installedBase.DisplayName -Like $software) { 
             $2 += "Installed: " + $software 
         }
     }
     # bad startups
     foreach ($start in $badStartup) { 
-        if ($startUps -contains $start) { 
+        if ($startUps -Like $start) { 
             $3 += "Startup: " + $start 
         }
     }
     # bad processes
     foreach ($running in $badProcesses) {
-        if ($runningProcesses.Name -contains $running) {
+        if ($runningProcesses.Name -Like $running) {
             $4 += "Process: " + $running 
         } 
     }


### PR DESCRIPTION
Contains is for containment, Like is for checking
```ps
PS> $a="KMSpico blah"
PS> $a -Like "KMS*"
True
PS> $a -Contains "KMS*"
False
PS> $a -Contains "KMS" 
False
```